### PR TITLE
Record dups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,4 @@ serde = {version = "1.0.167", features = ["derive"]}
 serde_json = "1.0.100"
 itertools = "0.11.0"
 oomfi = "0.1.2"
+xxhash-rust = { version = "0.8.6", features = ["xxh3"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,4 @@ noodles = { version = "0.41.0", features = ["fasta"] }
 serde = {version = "1.0.164", features = ["derive"]}
 serde_json = "1.0.96"
 itertools = "0.11.0"
+oomfi = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,14 +39,14 @@ path = "src/lib/lib.rs"
 
 [dependencies]
 anyhow = "1.0.71"
-clap = { version = "4.3.3", features = ["derive", "wrap_help","cargo"] }
+clap = { version = "4.3.11", features = ["derive", "wrap_help","cargo"] }
 grangers = { git = "https://github.com/COMBINE-lab/grangers.git", branch="dev", version = "0.1.4" }
 polars = { version = "0.30", features = ["lazy","dataframe_arithmetic","sort_multiple", "checked_arithmetic","rows","dtype-struct", "dtype-categorical", "list_eval","concat_str", "strings"]}
 peak_alloc = "0.2.0"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-noodles = { version = "0.41.0", features = ["fasta"] }
-serde = {version = "1.0.164", features = ["derive"]}
-serde_json = "1.0.96"
+noodles = { version = "0.44.0", features = ["fasta"] }
+serde = {version = "1.0.167", features = ["derive"]}
+serde_json = "1.0.100"
 itertools = "0.11.0"
 oomfi = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,13 +40,13 @@ path = "src/lib/lib.rs"
 [dependencies]
 anyhow = "1.0.71"
 clap = { version = "4.3.11", features = ["derive", "wrap_help","cargo"] }
-grangers = { git = "https://github.com/COMBINE-lab/grangers.git", branch="dev", version = "0.1.4" }
+grangers = { git = "https://github.com/COMBINE-lab/grangers.git", branch="dev", version = "0.2.0" }
 polars = { version = "0.30", features = ["lazy","dataframe_arithmetic","sort_multiple", "checked_arithmetic","rows","dtype-struct", "dtype-categorical", "list_eval","concat_str", "strings"]}
 peak_alloc = "0.2.0"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 noodles = { version = "0.44.0", features = ["fasta"] }
-serde = {version = "1.0.169", features = ["derive"]}
+serde = {version = "1.0.170", features = ["derive"]}
 serde_json = "1.0.100"
 itertools = "0.11.0"
 oomfi = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ peak_alloc = "0.2.0"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 noodles = { version = "0.44.0", features = ["fasta"] }
-serde = {version = "1.0.167", features = ["derive"]}
+serde = {version = "1.0.169", features = ["derive"]}
 serde_json = "1.0.100"
 itertools = "0.11.0"
 oomfi = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,4 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 noodles = { version = "0.41.0", features = ["fasta"] }
 serde = {version = "1.0.164", features = ["derive"]}
 serde_json = "1.0.96"
+itertools = "0.11.0"

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -179,16 +179,16 @@ impl SeqDedup {
 
     fn write_duplicate_info<P: AsRef<Path>>(&mut self, out_dir: P) -> anyhow::Result<()> {
         let dupfile = std::fs::OpenOptions::new()
-        .write(true)
-        .truncate(true)
-        .create(true)
-        .open(out_dir.as_ref().join("duplicate_entries.tsv"))
-        .with_context(|| {
-            format!(
-                "Could not open the output file {:?}",
-                out_dir.as_ref().join("duplicate_entries.tsv").as_os_str()
-            )
-        })?;
+            .write(true)
+            .truncate(true)
+            .create(true)
+            .open(out_dir.as_ref().join("duplicate_entries.tsv"))
+            .with_context(|| {
+                format!(
+                    "Could not open the output file {:?}",
+                    out_dir.as_ref().join("duplicate_entries.tsv").as_os_str()
+                )
+            })?;
 
         let mut dup_writer = BufWriter::new(dupfile);
 

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -458,6 +458,7 @@ pub fn make_ref(aug_ref_opts: AugRefOpts) -> anyhow::Result<()> {
                             concat_str([col(gene_id), col("intron_number")], "-I")
                                 .alias("t2g_tx_id"),
                         )
+                        .sort(gene_id, Default::default())
                         .collect()?;
 
                     intron_gr.write_sequences_with_filter(

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -196,7 +196,7 @@ impl SeqDedup {
         // retained key are adjacent
         self.collisions.sort();
 
-        writeln!(dup_writer, "RetainedRef\tDuplicateRef\n")?;
+        writeln!(dup_writer, "RetainedRef\tDuplicateRef")?;
 
         for (key, group) in &self.collisions.iter().group_by(|&x| &x.0) {
             for d in group {
@@ -493,6 +493,7 @@ pub fn make_ref(aug_ref_opts: AugRefOpts) -> anyhow::Result<()> {
                     gene_gr.df = gene_gr
                         .df
                         .lazy()
+                        .sort(gene_id, Default::default())
                         .with_column(col(gene_id).add(lit("-G")).alias("t2g_tx_id"))
                         .collect()?;
 


### PR DESCRIPTION
Several important changes and fixes:

* Fixes bug that would cause `roers` to fail with the `--dedup` option (due to a file `OpenMode` mistake).
* Matches functionality of `pyroe` by writing a `duplicate_entries.tsv` file containing, for each deduplicated (removed) sequence, the (retained, duplicate) pair.
* Vastly simplifies handling of sequence duplicates.
* Substantially improves (reduces) memory usage when deduplicating sequences.
* Prevents the IDs of duplicate sequences from being written from the `t2g` or `t2g_3col` files.
* Ensures a consistent order of deduplicate across runs by sorting the feature data frame prior to deduplicating (this was an issue because `polars`, unlike `pandas` backing `pyroe`, is multithreaded).
* Ensures that if there is an unspliced sequence that is a duplicate of a spliced sequence (e.g. like single-exon genes when preparing a `spliceu` reference), the spliced sequence will be retained and the unspliced sequence deduplicated.