### PR TITLE
Fix transcript IDs in `-a t` mode & Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,7 @@ path = "src/lib/lib.rs"
 [dependencies]
 anyhow = "1.0.95"
 clap = { version = "4.5.27", features = ["derive", "wrap_help", "cargo"] }
-grangers = { path = "../grangers", version = "0.5.0" }
-# grangers = { git = "https://github.com/COMBINE-lab/grangers.git", branch = "dev", version = "0.5.0" }
+grangers = { git = "https://github.com/COMBINE-lab/grangers.git", branch = "dev", version = "0.5.0" }
 polars = { version = "0.49.1", features = [
   "lazy",
   "dataframe_arithmetic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,9 @@ path = "src/lib/lib.rs"
 [dependencies]
 anyhow = "1.0.95"
 clap = { version = "4.5.27", features = ["derive", "wrap_help", "cargo"] }
-grangers = { git = "https://github.com/COMBINE-lab/grangers.git", branch = "dev", version = "0.5.0" }
-polars = { version = "0.45.1", features = [
+grangers = { path = "../grangers", version = "0.5.0" }
+# grangers = { git = "https://github.com/COMBINE-lab/grangers.git", branch = "dev", version = "0.5.0" }
+polars = { version = "0.49.1", features = [
   "lazy",
   "dataframe_arithmetic",
   "checked_arithmetic",
@@ -42,11 +43,13 @@ polars = { version = "0.45.1", features = [
   "list_eval",
   "concat_str",
   "strings",
+  "regex",
+  "timezones"
 ] }
-peak_alloc = "0.2.1"
+peak_alloc = "0.3.0"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-noodles = { version = "0.90.0", features = ["gtf", "gff", "fasta", "core"] }
+noodles = { version = "0.104.0", features = ["gtf", "gff", "fasta", "core"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.137"
 itertools = "0.14.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use tracing_subscriber::{filter::LevelFilter, fmt, prelude::*, EnvFilter};
 #[global_allocator]
 static PEAK_ALLOC: PeakAlloc = PeakAlloc;
 
-use clap::{command, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 
 #[derive(Debug, Subcommand)]
 pub enum Commands {


### PR DESCRIPTION
### Description

This PR addresses logic errors in Transcript Body (`-a t`) mode and updates core dependencies (including the fix for the `grangers` panic). I found the error because Yuan needs this in Forseti. 

Note that roers will only work with the updated grangers. 

I did not touch the version. We should bump it when merging.

**Key Changes:**

1.  **Fix `TranscriptBody` Mode (`-a t`):
    *   Previously, the code incorrectly used `gene_id` when generating headers for transcript sequences, leading to potential duplicates or incorrect mappings.
    *   **Fix:** Changed to use `transcript_id` (suffixed with `-T`) as the primary identifier for transcript bodies.
    *   Updated the `transcripts()` call to correctly preserve the `gene_id` column for downstream mapping.

2.  **Dependency Updates:**
    *   **`grangers`**: Updated to the latest version to fix the panic on fragmented Polars Series (`chunks.len() == 1`).
    *   **`polars`**: Bumped to `0.49.1`.
    *   **`noodles`**: Bumped to `0.104.0`. Updated code to match new API (e.g., using `noodles::fasta::io::Reader` and `Builder` pattern).
    *   **`peak_alloc`**: Bumped to `0.3.0`.

**Validation:**
- Confirmed that `-a t` mode now generates correct transcript headers (e.g., `ENST...-T`).
- Verified that `roers` builds and runs successfully with the updated dependency stack.
- Validated on full GRCh38 GTF annotation without panic.